### PR TITLE
fix: use single quotes in exports

### DIFF
--- a/engine/util.go
+++ b/engine/util.go
@@ -58,7 +58,7 @@ func writeEnv(w io.Writer, os, key, value string) {
 		fmt.Fprintf(w, "$Env:%s = %q", key, value)
 		fmt.Fprintln(w)
 	default:
-		fmt.Fprintf(w, "export %s=%q", key, value)
+		fmt.Fprintf(w, "export %s='%s'", key, value)
 		fmt.Fprintln(w)
 	}
 }

--- a/engine/util_test.go
+++ b/engine/util_test.go
@@ -6,6 +6,7 @@ package engine
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -43,7 +44,7 @@ func TestWriteSecrets(t *testing.T) {
 	sec := []*Secret{{Env: "a", Data: []byte("b")}}
 	writeSecrets(buf, "linux", sec)
 
-	want := "export a=\"b\"\n"
+	want := fmt.Sprintf("export a='b'\n")
 	if got := buf.String(); got != want {
 		t.Errorf("Want secret script %q, got %q", want, got)
 	}
@@ -61,7 +62,7 @@ func TestWriteEnv(t *testing.T) {
 	env := map[string]string{"a": "b", "c": "d"}
 	writeEnviron(buf, "linux", env)
 
-	want := "export a=\"b\"\nexport c=\"d\"\n"
+	want := fmt.Sprintf("export a='b'\nexport c='d'\n")
 	if got := buf.String(); got != want {
 		t.Errorf("Want environment script %q, got %q", want, got)
 	}


### PR DESCRIPTION
This fixes an edge case where the value of an exported variable can
contain command substitutions. For example, it is common to have PR
templates in GitHub, and if the template contains any backticks (`), the
DRONE_COMMIT_MESSAGE will contain command substitutions. In my case,
this caused our builds to fail because we give example make commands,
which are real targets, and this has unexpected consequences.

